### PR TITLE
fix: 仮チェックインの重複作成を防ぐ（DB制約 + Worker排他制御）(Issue#74)

### DIFF
--- a/app/src/main/java/com/zelretch/oreoregeo/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/zelretch/oreoregeo/data/local/AppDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [PlaceEntity::class, CheckinEntity::class, ProvisionalCheckinEntity::class],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -57,6 +57,41 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_4_5 = object : Migration(4, 5) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                // provisional_checkins に place_key + status のユニーク制約を追加
+                // SQLite は制約追加の ALTER TABLE をサポートしないため、テーブルを再作成する
+                database.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS provisional_checkins_new (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        place_key TEXT NOT NULL,
+                        place_name TEXT,
+                        detected_at INTEGER NOT NULL,
+                        lat REAL NOT NULL,
+                        lon REAL NOT NULL,
+                        status TEXT NOT NULL DEFAULT 'PENDING'
+                    )
+                    """.trimIndent()
+                )
+                database.execSQL(
+                    """
+                    CREATE UNIQUE INDEX IF NOT EXISTS index_provisional_checkins_place_key_status
+                    ON provisional_checkins_new (place_key, status)
+                    """.trimIndent()
+                )
+                database.execSQL(
+                    """
+                    INSERT OR IGNORE INTO provisional_checkins_new
+                    SELECT id, place_key, place_name, detected_at, lat, lon, status
+                    FROM provisional_checkins
+                    """.trimIndent()
+                )
+                database.execSQL("DROP TABLE provisional_checkins")
+                database.execSQL("ALTER TABLE provisional_checkins_new RENAME TO provisional_checkins")
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase = INSTANCE ?: synchronized(this) {
             val instance = Room.databaseBuilder(
                 context.applicationContext,
@@ -64,7 +99,7 @@ abstract class AppDatabase : RoomDatabase() {
                 "oreoregeo_database"
             )
                 .setJournalMode(JournalMode.WRITE_AHEAD_LOGGING) // Enable WAL
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
                 .addCallback(object : Callback() {})
                 .build()
             INSTANCE = instance

--- a/app/src/main/java/com/zelretch/oreoregeo/data/local/ProvisionalCheckinDao.kt
+++ b/app/src/main/java/com/zelretch/oreoregeo/data/local/ProvisionalCheckinDao.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface ProvisionalCheckinDao {
 
-    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insert(entity: ProvisionalCheckinEntity): Long
 
     @Query("SELECT * FROM provisional_checkins WHERE status = 'PENDING' ORDER BY detected_at DESC")

--- a/app/src/main/java/com/zelretch/oreoregeo/data/local/ProvisionalCheckinEntity.kt
+++ b/app/src/main/java/com/zelretch/oreoregeo/data/local/ProvisionalCheckinEntity.kt
@@ -1,9 +1,13 @@
 package com.zelretch.oreoregeo.data.local
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "provisional_checkins")
+@Entity(
+    tableName = "provisional_checkins",
+    indices = [Index(value = ["place_key", "status"], unique = true)]
+)
 data class ProvisionalCheckinEntity(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,

--- a/app/src/main/java/com/zelretch/oreoregeo/util/LocationTrackingWorker.kt
+++ b/app/src/main/java/com/zelretch/oreoregeo/util/LocationTrackingWorker.kt
@@ -8,6 +8,8 @@ import android.location.Location
 import androidx.core.content.ContextCompat
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
@@ -25,6 +27,7 @@ class LocationTrackingWorker(
 
     companion object {
         private const val WORK_NAME = "location_tracking"
+        private const val ONE_TIME_WORK_NAME = "location_tracking_one_time"
         private const val PREFS_NAME = "location_tracking_prefs"
         private const val KEY_LAST_LAT = "last_lat"
         private const val KEY_LAST_LON = "last_lon"
@@ -35,15 +38,19 @@ class LocationTrackingWorker(
         private const val INTERVAL_MINUTES = 15L
 
         fun schedule(context: Context) {
+            val workManager = WorkManager.getInstance(context)
             val request = PeriodicWorkRequestBuilder<LocationTrackingWorker>(
                 INTERVAL_MINUTES,
                 TimeUnit.MINUTES
             ).build()
-            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            workManager.enqueueUniquePeriodicWork(
                 WORK_NAME,
                 ExistingPeriodicWorkPolicy.KEEP,
                 request
             )
+            // 起動時に即時実行（同名のワークが既に実行中なら KEEP でスキップ）
+            val immediateRequest = OneTimeWorkRequestBuilder<LocationTrackingWorker>().build()
+            workManager.enqueueUniqueWork(ONE_TIME_WORK_NAME, ExistingWorkPolicy.KEEP, immediateRequest)
             Timber.d("LocationTrackingWorker scheduled")
         }
     }


### PR DESCRIPTION
## Summary
- `provisional_checkins` テーブルに `place_key + status` のユニークインデックスを追加（DB level での重複防止）
- DB version 4→5 の Migration でテーブル再作成（SQLite は ALTER TABLE での制約追加不可のため）
- `ProvisionalCheckinDao.insert` を `OnConflictStrategy.IGNORE` に変更し、重複時は無視
- `LocationTrackingWorker` の `OneTimeWorkRequest` を `enqueueUniqueWork(KEEP)` で排他制御し、並列実行を防止

Closes #74

## Test plan
- [ ] 既存DBからのMigrationが正常に動作することを確認
- [ ] 同一スポットで複数回 Worker が走っても仮チェックインが1件しか作成されないことを確認
- [ ] 全既存テストがパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)