### PR TITLE
fix: ネットワークエラーハンドリング改善とWorkerログ整理 (Issue#62, Issue#76)

### DIFF
--- a/app/src/androidTest/java/com/zelretch/oreoregeo/SearchScreenTest.kt
+++ b/app/src/androidTest/java/com/zelretch/oreoregeo/SearchScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.zelretch.oreoregeo.ui.SearchErrorType
 import com.zelretch.oreoregeo.ui.SearchScreen
 import com.zelretch.oreoregeo.ui.SearchState
 import org.junit.Rule
@@ -80,7 +81,7 @@ class SearchScreenTest {
         composeTestRule.setContent {
             OreoregeoTheme {
                 SearchScreen(
-                    searchState = SearchState.Error("テストエラー"),
+                    searchState = SearchState.Error(SearchErrorType.GENERIC),
                     searchRadius = 100,
                     onRadiusChange = {},
                     excludeUnnamed = false,
@@ -96,7 +97,9 @@ class SearchScreenTest {
         }
 
         // エラーメッセージが表示されることを確認
-        composeTestRule.onNodeWithText("テストエラー").assertIsDisplayed()
+        composeTestRule.onNodeWithText(
+            context.getString(R.string.error_network_generic)
+        ).assertIsDisplayed()
 
         // 再試行ボタンが表示されることを確認
         composeTestRule.onNodeWithText(
@@ -219,7 +222,7 @@ class SearchScreenTest {
         composeTestRule.setContent {
             OreoregeoTheme {
                 SearchScreen(
-                    searchState = SearchState.Error("テストエラー"),
+                    searchState = SearchState.Error(SearchErrorType.GENERIC),
                     searchRadius = 100,
                     onRadiusChange = {},
                     excludeUnnamed = false,

--- a/app/src/main/java/com/zelretch/oreoregeo/MainActivity.kt
+++ b/app/src/main/java/com/zelretch/oreoregeo/MainActivity.kt
@@ -620,7 +620,8 @@ fun MainScreen(
                     },
                     onCancel = {
                         navController.popBackStack()
-                    }
+                    },
+                    editState = editState
                 )
             }
         }

--- a/app/src/main/java/com/zelretch/oreoregeo/ui/AddPlaceScreen.kt
+++ b/app/src/main/java/com/zelretch/oreoregeo/ui/AddPlaceScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -74,6 +75,15 @@ fun AddPlaceScreen(
 
             if (!state.isMapReady) {
                 CircularProgressIndicator()
+            }
+
+            if (editState is OsmEditState.Error) {
+                Text(
+                    text = stringResource(R.string.error_save_failed),
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.align(Alignment.BottomCenter)
+                )
             }
         }
     }

--- a/app/src/main/java/com/zelretch/oreoregeo/ui/EditTagsScreen.kt
+++ b/app/src/main/java/com/zelretch/oreoregeo/ui/EditTagsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.zelretch.oreoregeo.R
+import com.zelretch.oreoregeo.ui.OsmEditState
 
 @Composable
 @Suppress("FunctionNaming")
@@ -43,7 +44,8 @@ fun EditTagsScreen(
     existingTags: Map<String, String>,
     onSave: (Long, Map<String, String>) -> Unit,
     onCancel: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    editState: OsmEditState = OsmEditState.Idle
 ) {
     // place_key (osm:node:12345) からノードIDを抽出
     val nodeId = placeKey.split(":").lastOrNull()?.toLongOrNull()
@@ -57,6 +59,12 @@ fun EditTagsScreen(
     LaunchedEffect(existingTags) {
         if (existingTags.isNotEmpty()) {
             tags = existingTags
+        }
+    }
+
+    LaunchedEffect(editState) {
+        if (editState is OsmEditState.Error) {
+            isSaving = false
         }
     }
 
@@ -98,6 +106,14 @@ fun EditTagsScreen(
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+
+        if (editState is OsmEditState.Error) {
+            Text(
+                text = stringResource(R.string.error_save_failed),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
 
         EditTagsActions(
             isSaving = isSaving,

--- a/app/src/main/java/com/zelretch/oreoregeo/ui/OsmEditViewModel.kt
+++ b/app/src/main/java/com/zelretch/oreoregeo/ui/OsmEditViewModel.kt
@@ -67,6 +67,12 @@ class OsmEditViewModel(
                 radiusMeters = DUPLICATE_CHECK_RADIUS_METERS,
                 excludeUnnamed = false
             )
+            if (nearbyResult.isFailure) {
+                _editState.value = OsmEditState.Error(
+                    nearbyResult.exceptionOrNull()?.message ?: "Failed to check duplicates"
+                )
+                return@launch
+            }
             val nearbyPlaces = nearbyResult.getOrDefault(emptyList()).take(MAX_DUPLICATES_DISPLAY)
 
             // 常に確認状態へ遷移する（重複があるかどうかに関わらず）

--- a/app/src/main/java/com/zelretch/oreoregeo/ui/SearchScreen.kt
+++ b/app/src/main/java/com/zelretch/oreoregeo/ui/SearchScreen.kt
@@ -220,7 +220,7 @@ private fun SearchResultsSection(
                 )
             }
         }
-        is SearchState.Error -> SearchErrorView(searchState.message, onRetryClick)
+        is SearchState.Error -> SearchErrorView(searchState.errorType, onRetryClick)
     }
 }
 
@@ -273,7 +273,12 @@ private fun PlacesList(
 
 @Composable
 @Suppress("FunctionNaming")
-private fun SearchErrorView(message: String, onRetryClick: () -> Unit) {
+private fun SearchErrorView(errorType: SearchErrorType, onRetryClick: () -> Unit) {
+    val message = when (errorType) {
+        SearchErrorType.TIMEOUT -> stringResource(R.string.error_network_timeout)
+        SearchErrorType.OFFLINE -> stringResource(R.string.error_network_offline)
+        SearchErrorType.GENERIC -> stringResource(R.string.error_network_generic)
+    }
     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(message, color = MaterialTheme.colorScheme.error)

--- a/app/src/main/java/com/zelretch/oreoregeo/ui/SearchViewModel.kt
+++ b/app/src/main/java/com/zelretch/oreoregeo/ui/SearchViewModel.kt
@@ -10,13 +10,17 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 import java.util.Locale
+
+enum class SearchErrorType { TIMEOUT, OFFLINE, GENERIC }
 
 sealed class SearchState {
     object Idle : SearchState()
     object Loading : SearchState()
     data class Success(val places: List<PlaceWithDistance>) : SearchState()
-    data class Error(val message: String) : SearchState()
+    data class Error(val errorType: SearchErrorType) : SearchState()
 }
 
 class SearchViewModel(
@@ -56,7 +60,14 @@ class SearchViewModel(
             )
             _searchState.value = result.fold(
                 onSuccess = { SearchState.Success(it) },
-                onFailure = { SearchState.Error(it.message ?: "Unknown error") }
+                onFailure = { e ->
+                    val errorType = when (e) {
+                        is SocketTimeoutException -> SearchErrorType.TIMEOUT
+                        is UnknownHostException -> SearchErrorType.OFFLINE
+                        else -> SearchErrorType.GENERIC
+                    }
+                    SearchState.Error(errorType)
+                }
             )
         }
     }

--- a/app/src/main/java/com/zelretch/oreoregeo/util/LocationTrackingWorker.kt
+++ b/app/src/main/java/com/zelretch/oreoregeo/util/LocationTrackingWorker.kt
@@ -64,12 +64,12 @@ class LocationTrackingWorker(
         repository.cleanupProvisionalCheckins()
 
         if (!hasLocationPermission()) {
-            Timber.d("Location permission not granted, skipping")
+            Timber.w("Location permission not granted, skipping")
             return Result.success()
         }
 
         val currentLocation = getCurrentLocation() ?: run {
-            Timber.d("Could not get current location")
+            Timber.w("Could not get current location")
             return Result.success()
         }
 
@@ -91,7 +91,7 @@ class LocationTrackingWorker(
             // 同じ場所にいる
             val elapsed = now - lastTimestamp
             if (elapsed >= STAY_DURATION_MS) {
-                Timber.d("User stayed at same location for ${elapsed / 60000} min, creating provisional check-in")
+                Timber.i("Stayed ${elapsed / 60000} min at same location, creating provisional check-in")
                 createProvisionalCheckin(currentLocation.latitude, currentLocation.longitude)
                 // 次の検出のためにタイムスタンプをリセット
                 saveLocation(currentLocation.latitude, currentLocation.longitude, now)
@@ -136,7 +136,7 @@ class LocationTrackingWorker(
             return
         }
         val nearest: PlaceWithDistance = nearbyResult.getOrNull()?.firstOrNull() ?: run {
-            Timber.d("No nearby places found for provisional check-in")
+            Timber.w("No nearby places found for provisional check-in")
             return
         }
         repository.createProvisionalCheckin(
@@ -145,5 +145,6 @@ class LocationTrackingWorker(
             lat = lat,
             lon = lon
         )
+        Timber.i("Provisional check-in created: ${nearest.place.name}")
     }
 }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -16,6 +16,10 @@
     <string name="edit_tags_desc">タグを編集</string>
     <string name="error_msg">エラー: %1$s</string>
     <string name="error_occurred">エラーが発生しました</string>
+    <string name="error_network_timeout">通信がタイムアウトしました。再度お試しください。</string>
+    <string name="error_network_offline">ネットワークに接続できません。接続を確認してください。</string>
+    <string name="error_network_generic">通信エラーが発生しました。再度お試しください。</string>
+    <string name="error_save_failed">保存に失敗しました。再度お試しください。</string>
     <string name="offline_mode">オフラインです。一部の機能が利用できません。</string>
     <string name="osm_sync_delay">OSMの変更が反映されるまで時間がかかる場合があります</string>
     <string name="duplicate_checkin">前回のチェックインから30分以内はチェックインできません</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,10 @@
     <string name="backup">Backup</string>
     <string name="searching">Searching nearby places&#8230;</string>
     <string name="error_occurred">An error occurred</string>
+    <string name="error_network_timeout">Request timed out. Please try again.</string>
+    <string name="error_network_offline">Cannot connect to network. Please check your connection.</string>
+    <string name="error_network_generic">Network error occurred. Please try again.</string>
+    <string name="error_save_failed">Failed to save. Please try again.</string>
     <string name="offline_mode">You are offline. Some features are unavailable.</string>
     <string name="osm_sync_delay">OSM changes may take time to reflect</string>
     <string name="place_name">Place Name</string>


### PR DESCRIPTION
## Summary

- **Issue#62**: SearchScreenのエラー表示を`SearchErrorType` enum（TIMEOUT/OFFLINE/GENERIC）で型付けし、例外種別に応じたユーザーフレンドリーなメッセージを表示。AddPlaceScreen・EditTagsScreenにもOsmEditState.Errorのエラー表示を追加。OsmEditViewModelの重複チェック失敗時のサイレント失敗を修正。
- **Issue#76**: LocationTrackingWorkerのログレベルを警告/情報に整理し、本番ログの可読性を向上。

## Changes

### Issue#62 ネットワークエラーハンドリング
- `SearchErrorType` enum（TIMEOUT/OFFLINE/GENERIC）を追加
- `SearchState.Error(message: String)` → `SearchState.Error(errorType: SearchErrorType)` に変更
- `SocketTimeoutException` → TIMEOUT、`UnknownHostException` → OFFLINE として分類
- `AddPlaceScreen`: `OsmEditState.Error` 時のエラーテキスト表示を追加
- `EditTagsScreen`: `editState` パラメータ追加、エラー表示と `isSaving` リセットを実装
- `OsmEditViewModel.requestCreatePlace`: 重複チェックAPIが失敗した場合、空リストを返して続行するのではなくエラー状態に遷移
- 英語/日本語の文字列リソースを追加（`error_network_timeout`, `error_network_offline`, `error_network_generic`, `error_save_failed`）

### Issue#76 LocationTrackingWorkerログ整理
- 権限未取得・位置情報取得失敗: `Timber.d` → `Timber.w`
- 滞在検出による仮チェックイン作成: `Timber.d` → `Timber.i`（滞在時間を含む詳細メッセージ）
- 付近スポットなし: `Timber.d` → `Timber.w`
- 仮チェックイン作成成功時のログを追加

## Test plan
- [x] `SearchScreenTest` 全8テスト通過（エミュレータ）
- [x] `AddPlaceScreenTest` 全15テスト通過
- [x] `EditTagsScreenTest` 全12テスト通過
- [x] ktlintCheck・detekt クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)